### PR TITLE
Namespace fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 group 'pt.tribeiro.flutter_pdf_viewer'
+
 version '1.0-SNAPSHOT'
 
 buildscript {
@@ -23,15 +24,34 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    namespace group
+
+    if (project.android.hasProperty("namespace")) {
+        namespace = group
+    }
+
     defaultConfig {
         minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }
+
     packagingOptions {
         exclude 'META-INF/services/javax.annotation.processing.Processor'
     }
 }
+
+task setupManifest {
+    doLast {
+        def manifestFile = file("$projectDir/src/main/AndroidManifest.xml")
+        if (project.android.hasProperty("namespace")) {
+            manifestFile.text = "<manifest />"
+        } else {
+            manifestFile.text = "<manifest package=\"${project["group"]}\" />"
+        }
+    }
+}
+
+preBuild.dependsOn(setupManifest)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-
+    namespace group
     defaultConfig {
         minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="pt.tribeiro.flutter_plugin_pdf_viewer">
-</manifest>
+<manifest />


### PR DESCRIPTION
I added a conditional setup for the namespace and package name for the Android platform. It is required for compatibility with both 8+ and 8- Gradle versions.